### PR TITLE
Add test plan PR 1780: Video thumbnails

### DIFF
--- a/Mobile/Android/Templates/Release_2.2.0/1780-video_thumbnails.md
+++ b/Mobile/Android/Templates/Release_2.2.0/1780-video_thumbnails.md
@@ -1,0 +1,27 @@
+###  Video thumbnails 
+
+#### Pr: https://github.com/owncloud/android/pull/1780 
+
+
+
+Precondition: in config.php file, add the following entry:
+
+  'enabledPreviewProviders' => array(
+	'OC\Preview\Movie'
+  )
+
+---
+
+ 
+| TestID | Test Case | Steps | Expected Result | Result | Related Comment |
+| :----: | :-------- | :---- | :-------------- | :----: | :-------------- |
+|**Formats supported**|||||||
+| 1 | FLV file | Upload an .FLV file | Thumbnail shown in list and grid view |  |  |
+| 2 | MKV file | Upload an .MKV file | Thumbnail shown in list and grid view |  |  |
+| 3 | 3GP file | Upload an .3GP file | Thumbnail shown in list and grid view |  |  |
+| 4 | MP4 file | Upload an .MP4 file | Thumbnail shown in list and grid view |  |  |
+| 5 | WEBM file | Upload an .WEBM file | Thumbnail shown in list and grid view |  |  |
+|**Formats unsupported**|||||||
+| 6 | AVI file | Upload an .AVI file | Thumbnail not shown in list and grid view  |  |  |
+| 7 | OGM file | Upload an .OGM file | Thumbnail not shown in list and grid view |  |  |
+| 8 | MOV file | Upload an .MOV file | Thumbnail not shown in list and grid view |  |  |


### PR DESCRIPTION
cc @owncloud/android-developers 

I have supposed that the supported formats for the thumbnails are the supported formats to play videos in the official documentation:

https://developer.android.com/guide/appendix/media-formats.html

If i am mistaked, you can correct me.
