### PR TITLE
Add check of Travis UI test results

### DIFF
--- a/Server/Test_Plan_Simplified_Smoke_Test.md
+++ b/Server/Test_Plan_Simplified_Smoke_Test.md
@@ -2,6 +2,8 @@
 
 | Test Case                                | Expected Result                          | Result      | Related Comment |
 | ---------------------------------------- | ---------------------------------------- | ----------- | --------------- |
+| **Automated Checks**                     |                                          |             |                 |
+| Travis nightly cron job with UI tests on chrome, firefox, Edge, IE11 | All tests pass on the release branch | :construction: | Note: IE11 tests have intermittent issues with IE webdriver, it is acceptable to restart failed test suites to see that they will pass |
 | **Web UI**                               |                                          |             |                 |
 | Login with admin user.                   | Admin logs in.                           | :gear: |                 |
 | Create a text file.                      | Text editor can open, file is saved.     | :gear: |                 |


### PR DESCRIPTION
Travis does a nightly run of UI tests on chrome, firefox, Edge and IE11. We need to ensure that we check those results on the relevant branch being used for the release.

IE11 tests are not fully reliable, so put a note about that.