### PR TITLE
Update Test_Plan_OAuth2.md

### DIFF
--- a/Server/Test_Plan_OAuth2.md
+++ b/Server/Test_Plan_OAuth2.md
@@ -14,7 +14,7 @@ This aims to be a client-agnostic testplan for the OAuth2 application, centered 
 | Disable OAuth2 app via CLI using `occ app:disable oauth2` | - The apps gets disabled <br> - Previously mentioned header goes away in further requests | :construction: | |
 | **Registered Clients** | | |
 | Default clients | The default Registered clients are included among the "Settings > Admin > User Authentication" OAuth 2.0: Registered Clients | :construction: | See https://github.com/owncloud/oauth2/pull/38 for the default values |
-| Register new Client | 64-character-length `client_id` and `client_secret` are generated together with a (optional) Client Name and a (required) Redirection URL | :construction: | |
+| Register new Client | 64-character-length `client_id` and `client_secret` are generated together with a (required) Client Name and a (required) Redirection URL | :construction: | |
 | Remove a Client | - Confirmation dialog is prompted before removal <br> - All client sessions opened from those clients get removed | :construction: | |
 | **Unregistered Clients** | | |
 | Authentication flow from an unregistered client | Unsuccessful [Authorization Request] | :gear: | Browser displays the "Request not valid" screen.|


### PR DESCRIPTION
The testplan says, the name is optional. It seems it is required:

![image](https://user-images.githubusercontent.com/1108546/79874147-49adce00-83e8-11ea-8403-ab917f809430.png)

Seen with 10.4.0 and https://github.com/owncloud/oauth2/releases/download/v0.4.4RC1/oauth2-0.4.4RC1.tar.gz

Found by @iHerrmann77 
